### PR TITLE
fixed: python3.5 open notebook throw exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+/.project
+/.pydevproject
+/.gitignore

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,8 @@ You can either use command line arguments to configure Jupyter to use the HDFSCo
         --HDFSContentsManager.hdfs_namenode_host='localhost' \
         --HDFSContentsManager.hdfs_namenode_port=9000 \
         --HDFSContentsManager.hdfs_user='myuser' \
-        --HDFSContentsManager.root_dir='/user/myuser/'
+        --HDFSContentsManager.root_dir='/user/myuser/' \
+        --HDFSContentsManager.auto_create_root_dir=False
 
 .. code: bash
 

--- a/hdfscontents/hdfsio.py
+++ b/hdfscontents/hdfsio.py
@@ -14,6 +14,7 @@ from notebook.utils import (
     to_os_path,
 )
 import nbformat
+import io
 
 from pydoop.hdfs.path import split
 from ipython_genutils.py3compat import str_to_unicode
@@ -278,7 +279,10 @@ class HDFSManagerMixin(Configurable):
         # TODO: check for open errors
         with self.hdfs.open_file(hdfs_path, 'r') as f:
             try:
-                return nbformat.read(f, as_version=as_version)
+                s = f.read()
+                if isinstance(s, bytes):
+                    s = s.decode("utf8")
+                return nbformat.read(io.StringIO(s), as_version=as_version)
             except Exception as e:
                 e_orig = e
 


### PR DESCRIPTION
In python3.5 open notebook throw TypeError("the JSON object must be str, not 'bytes'",)