### PR TITLE
nbconvert returns a unicode string, encode it and write it to hdfs

### DIFF
--- a/hdfscontents/hdfsio.py
+++ b/hdfscontents/hdfsio.py
@@ -308,8 +308,12 @@ class HDFSManagerMixin(Configurable):
 
     def _save_notebook(self, hdfs_path, nb):
         """Save a notebook to an os_path."""
+        # Convert the notebook to unicode string
+        notebook_json = nbformat.writes(nb, version=nbformat.NO_CONVERT)
+
         with self.atomic_writing(hdfs_path) as f:
-            nbformat.write(nb, f, version=nbformat.NO_CONVERT)
+            # Write the notebook on hdfs
+            f.write(notebook_json.encode('utf-8'))
 
     def _read_file(self, hdfs_path, format):
         """Read a non-notebook file.


### PR DESCRIPTION
Currently we pass a fd to the `nbformat.write` method which takes care of calling the `write` method on the fd. The problem is that nbformat passes a string to the `write` method, not a byte array. As such the call fails on python 3.

With this PR nbformat returns a string which we explicitly encode with utf-8 and we pass the result to the pydoop fd.