### PR TITLE
Add support for Checkpoints-only feature and multiple checkpoints per file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 HDFS Contents Manager for Jupyter Notebooks
 ===========================================
 
-A contents manager for Jupyter that uses the Hadoop File System (HDFS) to store Notebooks and files
+A contents manager for Jupyter that uses the Hadoop File System (HDFS) to store Notebooks and files. HDFSContents' HDFSContentsManager class can be used to replace all local filesystem storage with Hadoop's File System storage, while its HDFSCheckpoints class can be used to replace just the IPython's checkpoint storage.
 
 
 Getting Started

--- a/examples/example_hdfs_checkpoint_notebook_config.py
+++ b/examples/example_hdfs_checkpoint_notebook_config.py
@@ -1,0 +1,9 @@
+from hdfscontents.hdfscheckpoints import HDFSCheckpoints
+
+# Tell IPython to use HDFSCheckpoints for checkpoint storage.
+c.ContentsManager.checkpoints_class = HDFSCheckpoints
+
+c.HDFSCheckpoints.hdfs_namenode_host='<namenode_host_ip>'
+c.HDFSCheckpoints.hdfs_namenode_port=8020
+c.HDFSCheckpoints.root_dir='/user/amangarg'
+c.HDFSCheckpoints.hdfs_user='hdfs'

--- a/examples/example_hdfs_checkpoint_notebook_config.py
+++ b/examples/example_hdfs_checkpoint_notebook_config.py
@@ -5,5 +5,5 @@ c.ContentsManager.checkpoints_class = HDFSCheckpoints
 
 c.HDFSCheckpoints.hdfs_namenode_host='<namenode_host_ip>'
 c.HDFSCheckpoints.hdfs_namenode_port=8020
-c.HDFSCheckpoints.root_dir='/user/amangarg'
+c.HDFSCheckpoints.root_dir='/user/hdfs_user'
 c.HDFSCheckpoints.hdfs_user='hdfs'

--- a/examples/example_hdfs_contents_notebook_config.py
+++ b/examples/example_hdfs_contents_notebook_config.py
@@ -1,0 +1,9 @@
+from hdfscontents.hdfsmanager import HDFSContentsManager
+
+# Tell IPython to use HDFSContentsManager as ContentsManager .
+c.NotebookApp.contents_manager_class = HDFSContentsManager
+
+c.HDFSCheckpoints.hdfs_namenode_host='<namenode_host_ip>'
+c.HDFSCheckpoints.hdfs_namenode_port=8020
+c.HDFSCheckpoints.root_dir='/user/amangarg'
+c.HDFSCheckpoints.hdfs_user='hdfs'

--- a/examples/example_hdfs_contents_notebook_config.py
+++ b/examples/example_hdfs_contents_notebook_config.py
@@ -5,5 +5,5 @@ c.NotebookApp.contents_manager_class = HDFSContentsManager
 
 c.HDFSCheckpoints.hdfs_namenode_host='<namenode_host_ip>'
 c.HDFSCheckpoints.hdfs_namenode_port=8020
-c.HDFSCheckpoints.root_dir='/user/amangarg'
+c.HDFSCheckpoints.root_dir='/user/hdfs_user'
 c.HDFSCheckpoints.hdfs_user='hdfs'

--- a/hdfscontents/hdfscheckpoints.py
+++ b/hdfscontents/hdfscheckpoints.py
@@ -1,12 +1,14 @@
 """
 HDFS-based Checkpoints implementations.
 """
+import pdb
 import os
 from hdfscontents.hdfsio import HDFSManagerMixin
 from tornado.web import HTTPError
 from notebook.services.contents.checkpoints import Checkpoints
+from pydoop.hdfs.fs import hdfs as HDFS
 
-from traitlets import Unicode
+from traitlets import Unicode, Instance, Integer, default
 try:  # new notebook
     from notebook import _tz as tz
 except ImportError: # old notebook
@@ -30,14 +32,15 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
         """,
     )
 
-    hdfs = None
-    root_dire = None
+    # hdfs = None
+    # root_dire = None
+
 
     # ContentsManager-dependent checkpoint API
     def create_checkpoint(self, contents_mgr, path):
         """Create a checkpoint."""
         checkpoint_id = u'checkpoint'
-        src_path = contents_mgr._get_hdfs_path(path)
+        src_path = contents_mgr._get_os_path(path)
         dest_path = self.checkpoint_path(checkpoint_id, path)
         self._copy(src_path, dest_path)
         return self.checkpoint_model(checkpoint_id, dest_path)
@@ -45,7 +48,7 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
     def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
         """Restore a checkpoint."""
         src_path = self.checkpoint_path(checkpoint_id, path)
-        dest_path = contents_mgr._get_hdfs_path(path)
+        dest_path = contents_mgr._get_os_path(path)
         self._copy(src_path, dest_path)
 
     # ContentsManager-independent checkpoint API

--- a/hdfscontents/hdfscheckpoints.py
+++ b/hdfscontents/hdfscheckpoints.py
@@ -85,6 +85,8 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
         """
         path = path.strip('/')
         checkpoint_id_list = self.get_checkpoints_list(path)
+        # TODO: Sort by 'LastModified' instead of checkpoint id
+        checkpoint_id_list.sort(reverse=True)
         checkpoints_list = []
         for checkpoint_id in checkpoint_id_list:
             cp_path = self.checkpoint_path(checkpoint_id, path)

--- a/hdfscontents/hdfscheckpoints.py
+++ b/hdfscontents/hdfscheckpoints.py
@@ -33,17 +33,14 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
         """,
     )
 
-    # hdfs = None
-    # root_dire = None
-
     # ContentsManager-dependent checkpoint API
     def create_checkpoint(self, contents_mgr, path):
         """Create a checkpoint."""
-        src_path = contents_mgr._get_os_path(path)
-        #print("src_path: ",src_path)
-
-        checkpoint_id = self.get_checkpoint_id(path)
-
+        if hasattr(contents_mgr,'_get_os_path'): #For checkpointing-only case
+            src_path = contents_mgr._get_os_path(path)
+        else:
+            src_path = contents_mgr._get_hdfs_path(path)
+        checkpoint_id = self.get_new_checkpoint_id(path)
         dest_path = self.checkpoint_path(checkpoint_id, path)
         self._copy(src_path, dest_path)
         return self.checkpoint_model(checkpoint_id, dest_path)
@@ -51,7 +48,10 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
     def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
         """Restore a checkpoint."""
         src_path = self.checkpoint_path(checkpoint_id, path)
-        dest_path = contents_mgr._get_os_path(path)
+        if hasattr(contents_mgr, '_get_os_path'):  # For checkpointing-only case
+            dest_path = contents_mgr._get_os_path(path)
+        else:
+            dest_path = contents_mgr._get_hdfs_path(path)
         self._copy(src_path, dest_path)
 
     # ContentsManager-independent checkpoint API
@@ -84,16 +84,10 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
         This contents manager currently only supports one checkpoint per file.
         """
         path = path.strip('/')
-        #print("path: ",path)
-
         checkpoint_id_list = self.get_checkpoints_list(path)
-
         checkpoints_list = []
         for checkpoint_id in checkpoint_id_list:
             cp_path = self.checkpoint_path(checkpoint_id, path)
-            # print("cp_path: ",cp_path)
-            # print("get_hdfs_path: ",self._get_hdfs_path(path))
-
             if self._hdfs_file_exists(cp_path):
                 checkpoints_list.append(self.checkpoint_model(checkpoint_id, cp_path))
         return checkpoints_list
@@ -123,7 +117,6 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
         parent = parent.strip('/')
         hdfs_path = self._get_hdfs_path(path=parent)
         full_checkpoint_dir = os.path.join(hdfs_path, self.checkpoint_dir)
-        #print("full checkpoint dir: ", full_checkpoint_dir)
         for filepath_dict in self.hdfs.list_directory(full_checkpoint_dir):
             filepath = filepath_dict['name']
             filepath = filepath.strip('/')
@@ -136,29 +129,21 @@ class HDFSCheckpoints(HDFSManagerMixin, Checkpoints):
         #print("checkpoints list: ",checkpoints_list)
         return checkpoints_list
 
-    def get_checkpoint_id(self,path):
+    def get_new_checkpoint_id(self,path):
         """return checkpoint_id for new checkpoint"""
         path = path.strip('/')
         parent, name = ('/' + path).rsplit('/', 1)
         name,ext = os.path.splitext(name)
-        #print("name: ",name)
         parent = parent.strip('/')
-        #print("parent: ",parent)
         hdfs_path = self._get_hdfs_path(path=parent)
-        #print("hdfs_path: ",hdfs_path)
         full_checkpoint_dir = os.path.join(hdfs_path,self.checkpoint_dir)+'/'
-        #print("full_checkpoint_dir: ", full_checkpoint_dir)
-        max_id = 1
+        max_id = 0
         for filepath_dict in self.hdfs.list_directory(full_checkpoint_dir):
             filepath = filepath_dict['name']
-            # print("filepath: ",filepath)
             filepath = filepath.strip('/')
             parent, filename = ('/' + filepath).rsplit('/', 1)
-            parent = parent.strip('/')
-            #print("filename: ",filename)
             basename, ext = os.path.splitext(filename)
             filename,checkpoint_id = basename.rsplit('-',1)
-            #print("checkpoint_id: ",checkpoint_id)
             if filename == name and checkpoint_id.isnumeric() and int(checkpoint_id) > max_id:
                 max_id = int(checkpoint_id)
         return str(int(max_id) + 1)

--- a/hdfscontents/hdfsio.py
+++ b/hdfscontents/hdfsio.py
@@ -42,6 +42,8 @@ def path_to_invalid(path):
 def hdfs_copy_file(hdfs, src, dst):
     chunk = 2 ** 16
     # TODO: check if we need to specify replication
+
+    # TODO: Better way to support check-pointing only usecase
     try:
         with hdfs.open_file(dst, 'w') as f1:
             with hdfs.open_file(src, 'r') as f2:
@@ -50,6 +52,7 @@ def hdfs_copy_file(hdfs, src, dst):
                     if len(out) == 0:
                         break
                     f1.write(out)
+    # When source file is not on HDFS
     except:
         with hdfs.open_file(dst, 'w') as f1:
             with open(src, 'rb') as f2:

--- a/hdfscontents/hdfsmanager.py
+++ b/hdfscontents/hdfsmanager.py
@@ -29,23 +29,20 @@ class HDFSContentsManager(ContentsManager, HDFSManagerMixin):
     ContentsManager that persists to HDFS filesystem local filesystem.
     """
 
-    hdfs_namenode_host = Unicode(u'localhost', config=True, help='The HDFS namenode host')
-    hdfs_namenode_port = Integer(9000, config=True, help='The HDFS namenode port')
-    hdfs_user = Unicode(None, allow_none=True, config=True, help='The HDFS user name')
+    # hdfs_namenode_host = Unicode(u'localhost', config=True, help='The HDFS namenode host')
+    # hdfs_namenode_port = Integer(9000, config=True, help='The HDFS namenode port')
+    # hdfs_user = Unicode(None, allow_none=True, config=True, help='The HDFS user name')
+    #
+    # root_dir = Unicode(u'/', config=True, help='The HDFS root directory to use')
+    #
+    # # The pydoop HDFS connection object used to interact with HDFS cluster.
+    # hdfs = Instance(HDFS, config=True)
 
-    root_dir = Unicode(u'/', config=True, help='The HDFS root directory to use')
-
-    # The pydoop HDFS connection object used to interact with HDFS cluster.
-    hdfs = Instance(HDFS, config=True)
-
-    @default('hdfs')
-    def _default_hdfs(self):
-        return HDFS(host=self.hdfs_namenode_host, port=self.hdfs_namenode_port, user=self.hdfs_user)  # groups=None
+    # @default('hdfs')
+    # def _default_hdfs(self):
+    #     return HDFS(host=self.hdfs_namenode_host, port=self.hdfs_namenode_port, user=self.hdfs_user)  # groups=None
 
     def _checkpoints_class_default(self):
-        # TODO: a better way to pass hdfs and root_dir?
-        HDFSCheckpoints.hdfs = self.hdfs
-        HDFSCheckpoints.root_dir = self.root_dir
         return HDFSCheckpoints
 
     # ContentsManager API part 1: methods that must be

--- a/hdfscontents/hdfsmanager.py
+++ b/hdfscontents/hdfsmanager.py
@@ -338,7 +338,6 @@ class HDFSContentsManager(ContentsManager, HDFSManagerMixin):
 
     def delete_file(self, path):
         """Delete file at path."""
-        # TODO: Deleting all associated (multiple) checkpoints
         path = path.strip('/')
         hdfs_path = to_os_path(path, self.root_dir)
         if self._hdfs_dir_exists(hdfs_path):


### PR DESCRIPTION
This PR is for adding two features:
- **Checkpoints-only**: Only the checkpoints of the files/notebooks will be stored on HDFS (Files and Notebooks will still be on the local file system)
- **Multiple checkpoints per notebook**: Allow multiple checkpoints per notebook. The current ContentsManager only allows one checkpoint per notebook.

Both of these features are inspired from [PGContents](https://github.com/quantopian/pgcontents), which is a PostgresQL-backed ContentsManager and supports these features.

For _checkpoints-only_, the attributes of the `HDFSContentsManager` class (`hdfs_namenode_host`, `hdfs_namenode_port`, `root_dir`, `hdfs_user`) were move to the Base class `HDFSManagerMixin`, so that the attributes are accessible by both `HDFSCheckpoints` and `HDFSContentsManager`.
The checkpoints are stored following the same relative path on the HDFS, as that of the Notebook on the local file system. If the Notebook server is started in <local_root> and a checkpoint is saved for a Notebook in <local_root>/Folder1/Notebook1.ipynb, then the checkpoints would be stored in <hdfs_root>/Folder1/.ipynb_checkpoints 

For _multiple checkpoints_, the default value of `checkpoint_id` was changed from "checkpoint" to a number (starting from 1) which increments on every checkpoint. There's no limit on the number of checkpoints per file.
When a Notebook is deleted, all the associated checkpoints are also deleted. 

Example configuration files for using Checkpoints-only and the whole ContentsManager have been included in the examples folder.

**Note: JupyterLab UI does not support multiple checkpoints. You can only see the last checkpoint.**
